### PR TITLE
Change nginx conf to add source maps behind basic auth

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -30,7 +30,7 @@ echo "-----> Installed ${nginx_version} to /app/bin"
 
 mkdir -p $build_dir/config
 cp $bp_dir/scripts/config/templates/mime.types $build_dir/config
-cp $bp_dir/scripts/config/htpasswd $build_dir/config/.htpasswd
+echo $SOURCE_MAP_HTPASSWD > $build_dir/config/.htpasswd
 
 mkdir -p $build_dir/logs
 

--- a/bin/compile
+++ b/bin/compile
@@ -30,6 +30,7 @@ echo "-----> Installed ${nginx_version} to /app/bin"
 
 mkdir -p $build_dir/config
 cp $bp_dir/scripts/config/templates/mime.types $build_dir/config
+cp $bp_dir/scripts/config/htpasswd $build_dir/config/.htpasswd
 
 mkdir -p $build_dir/logs
 

--- a/scripts/config/htpasswd
+++ b/scripts/config/htpasswd
@@ -1,1 +1,0 @@
-airbase:

--- a/scripts/config/htpasswd
+++ b/scripts/config/htpasswd
@@ -1,0 +1,1 @@
+airbase:

--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -61,6 +61,11 @@ http {
     <% end %>
     }
 
+    location ~* ^/static/.*js.map$ {
+      auth_basic "Stealth Mode";
+      auth_basic_user_file /app/bin/config/.htpasswd
+    }
+
   <% if clean_urls %>
     location ~ \.html$ {
       try_files $uri =404;


### PR DESCRIPTION
This PR changes nginx configuration to protect source maps behind HTTP basic auth. This way, we can keep source maps on the server but they will only be accessible to the internal team.

- [x] Get password from heroku env and place it in .htpasswd
- [x] Update the sentry-sourcemap build pack to not delete the source maps after syncing