### PR TITLE
Protect map files using HTTP Basic Auth via nginx conf

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -32,6 +32,7 @@ mkdir -p $build_dir/config
 cp $bp_dir/scripts/config/templates/mime.types $build_dir/config
 
 echo "~~~~~> Create .htpasswd file for source maps"
+touch $build_dir/config/.htpasswd
 echo $SOURCE_MAP_HTPASSWD > $build_dir/config/.htpasswd
 
 mkdir -p $build_dir/logs

--- a/bin/compile
+++ b/bin/compile
@@ -30,7 +30,7 @@ echo "-----> Installed ${nginx_version} to /app/bin"
 
 mkdir -p $build_dir/config
 cp $bp_dir/scripts/config/templates/mime.types $build_dir/config
-cp $bp_dir/scripts/config/htpasswd $build_dir/config/.htpasswd
+echo $SOURCE_MAP_HTPASSWD > $build_dir/config/.htpasswd
 
 mkdir -p $build_dir/logs
 

--- a/bin/compile
+++ b/bin/compile
@@ -33,7 +33,7 @@ cp $bp_dir/scripts/config/templates/mime.types $build_dir/config
 
 echo "~~~~~> Create .htpasswd file for source maps"
 touch $build_dir/config/.htpasswd
-echo $SOURCE_MAP_HTPASSWD > $build_dir/config/.htpasswd
+cat $env_dir/SOURCE_MAP_HTPASSWD > $build_dir/config/.htpasswd
 
 mkdir -p $build_dir/logs
 

--- a/bin/compile
+++ b/bin/compile
@@ -30,6 +30,7 @@ echo "-----> Installed ${nginx_version} to /app/bin"
 
 mkdir -p $build_dir/config
 cp $bp_dir/scripts/config/templates/mime.types $build_dir/config
+cp $bp_dir/scripts/config/htpasswd $build_dir/config/.htpasswd
 
 mkdir -p $build_dir/logs
 

--- a/bin/compile
+++ b/bin/compile
@@ -30,6 +30,8 @@ echo "-----> Installed ${nginx_version} to /app/bin"
 
 mkdir -p $build_dir/config
 cp $bp_dir/scripts/config/templates/mime.types $build_dir/config
+
+echo "~~~~~> Create .htpasswd file for source maps"
 echo $SOURCE_MAP_HTPASSWD > $build_dir/config/.htpasswd
 
 mkdir -p $build_dir/logs

--- a/scripts/config/htpasswd
+++ b/scripts/config/htpasswd
@@ -1,1 +1,0 @@
-airbase:

--- a/scripts/config/htpasswd
+++ b/scripts/config/htpasswd
@@ -1,0 +1,1 @@
+airbase:

--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -64,6 +64,7 @@ http {
     location ~* ^.*js.map$ {
       auth_basic "Stealth Mode";
       auth_basic_user_file /app/config/.htpasswd;
+      default_type text/plain;
     }
 
   <% if clean_urls %>

--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -63,7 +63,7 @@ http {
 
     location ~* ^.*js.map$ {
       auth_basic "Stealth Mode";
-      auth_basic_user_file /app/bin/config/.htpasswd;
+      auth_basic_user_file /app/config/.htpasswd;
     }
 
   <% if clean_urls %>

--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -61,6 +61,11 @@ http {
     <% end %>
     }
 
+    location ~* ^/static/.*js.map$ {
+      auth_basic "Stealth Mode";
+      auth_basic_user_file /app/bin/config/.htpasswd
+    }
+
   <% if clean_urls %>
     location ~ \.html$ {
       try_files $uri =404;

--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -63,7 +63,7 @@ http {
 
     location ~* ^/static/.*js.map$ {
       auth_basic "Stealth Mode";
-      auth_basic_user_file /app/bin/config/.htpasswd
+      auth_basic_user_file /app/bin/config/.htpasswd;
     }
 
   <% if clean_urls %>

--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -61,7 +61,7 @@ http {
     <% end %>
     }
 
-    location ~* ^/static/.*js.map$ {
+    location ~* ^.*js.map$ {
       auth_basic "Stealth Mode";
       auth_basic_user_file /app/bin/config/.htpasswd;
     }


### PR DESCRIPTION
Fixes https://github.com/Airbase/airbase-frontend/issues/1796
Depends on https://github.com/Airbase/buildpack-sentry-sourcemaps/pull/1

We are building a setup to allow internal teams to access source map while keeping it secure from public. This is possible by securing *.js.map behind HTTP Basic Auth via nginx conf. 

To make it work, open any url on the domain with *.js.map. For e.g. https://stage.airbase.io/1.js.map 
It will prompt for username/password. Enter the one shared by admin. Once entered, chrome will save this password for all subsequent request and you should be seamlessly able to see sourcemaps in Devtools. 

Use following username and password to test the PR app
airbase / sourcemap123