### PR TITLE
Storybook

### DIFF
--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -42,7 +42,7 @@ http {
     charset <%= encoding %>;
     port_in_redirect off;
     keepalive_timeout 5;
-    root <%= root %>;
+    root /app/build/storybook;
     client_max_body_size <%= max_body_size %>;
   <% if error_page %>
     error_page 404 500 /<%= error_page %>;


### PR DESCRIPTION
This PR only exist to demonstrate the changes made for storybook dyno in the buildpack. The branch `storybook` is actively used by storybook heroku app and it shouldn't not be deleted.